### PR TITLE
Patch/correct i event sink contract

### DIFF
--- a/libc.eventbus.tests/libc.eventbus.tests.csproj
+++ b/libc.eventbus.tests/libc.eventbus.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0;net7.0</TargetFramework>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/libc.eventbus.tests/libc.eventbus.tests.csproj
+++ b/libc.eventbus.tests/libc.eventbus.tests.csproj
@@ -6,10 +6,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-		<PackageReference Include="coverlet.collector" Version="3.2.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/libc.eventbus/System/DefaultEventBus.cs
+++ b/libc.eventbus/System/DefaultEventBus.cs
@@ -21,7 +21,7 @@ namespace libc.eventbus.System
     ///     <inheritdoc />
     /// </summary>
     /// <param name="handlers"></param>
-    public override void RegisterCatchAllHandler(IEnumerable<ICatchAllEventHandler> handlers)
+    public override void RegisterCatchAllHandler(params ICatchAllEventHandler[] handlers)
     {
       if (handlers == null) return;
 
@@ -32,7 +32,7 @@ namespace libc.eventbus.System
     ///     <inheritdoc />
     /// </summary>
     /// <param name="handlers"></param>
-    public override void UnregisterCatchAllHandler(IEnumerable<ICatchAllEventHandler> handlers)
+    public override void UnregisterCatchAllHandler(params ICatchAllEventHandler[] handlers)
     {
       if (handlers == null) return;
 
@@ -45,7 +45,7 @@ namespace libc.eventbus.System
     /// <typeparam name="TEvent"></typeparam>
     /// <typeparam name="TEventHandler"></typeparam>
     /// <param name="handlers"></param>
-    public override void Subscribe<TEvent, TEventHandler>(IEnumerable<TEventHandler> handlers)
+    public override void Subscribe<TEvent, TEventHandler>(params TEventHandler[] handlers)
     {
       if (handlers == null) return;
 
@@ -58,7 +58,7 @@ namespace libc.eventbus.System
     /// <typeparam name="TEvent"></typeparam>
     /// <typeparam name="TEventHandler"></typeparam>
     /// <param name="handlers"></param>
-    public override void Unsubscribe<TEvent, TEventHandler>(IEnumerable<TEventHandler> handlers)
+    public override void Unsubscribe<TEvent, TEventHandler>(params TEventHandler[] handlers)
     {
       if (handlers == null) return;
 
@@ -162,10 +162,10 @@ namespace libc.eventbus.System
 
       public IEnumerable<IEventHandler<TEvent>> GetHandlers<TEvent>() where TEvent : IEvent
       {
-        if (_disposing || _disposed) return new IEventHandler<TEvent>[0];
+        if (_disposing || _disposed) return Array.Empty<IEventHandler<TEvent>>();
         var type = typeof(TEvent);
 
-        if (!Handlers.ContainsKey(type)) return new IEventHandler<TEvent>[0];
+        if (!Handlers.ContainsKey(type)) return Array.Empty<IEventHandler<TEvent>>();
 
         return Handlers[type].Keys.OfType<IEventHandler<TEvent>>();
       }

--- a/libc.eventbus/System/EventBus.cs
+++ b/libc.eventbus/System/EventBus.cs
@@ -83,7 +83,7 @@ namespace libc.eventbus.System
     /// <typeparam name="TEvent"></typeparam>
     /// <typeparam name="TEventHandler"></typeparam>
     /// <param name="handlers"></param>
-    public abstract void Subscribe<TEvent, TEventHandler>(IEnumerable<TEventHandler> handlers)
+    public abstract void Subscribe<TEvent, TEventHandler>(params TEventHandler[] handlers)
         where TEvent : IEvent
         where TEventHandler : IEventHandler<TEvent>;
 
@@ -92,86 +92,22 @@ namespace libc.eventbus.System
     /// </summary>
     /// <typeparam name="TEvent"></typeparam>
     /// <typeparam name="TEventHandler"></typeparam>
-    /// <param name="handler"></param>
-    public void Subscribe<TEvent, TEventHandler>(TEventHandler handler)
-        where TEvent : IEvent
-        where TEventHandler : IEventHandler<TEvent>
-    {
-      if (handler == null) return;
-
-      Subscribe<TEvent, TEventHandler>(new[]
-      {
-                handler
-            });
-    }
-
-    /// <summary>
-    ///     <inheritdoc />
-    /// </summary>
-    /// <typeparam name="TEvent"></typeparam>
-    /// <typeparam name="TEventHandler"></typeparam>
     /// <param name="handlers"></param>
-    public abstract void Unsubscribe<TEvent, TEventHandler>(IEnumerable<TEventHandler> handlers)
+    public abstract void Unsubscribe<TEvent, TEventHandler>(params TEventHandler[] handlers)
         where TEvent : IEvent
         where TEventHandler : IEventHandler<TEvent>;
 
     /// <summary>
     ///     <inheritdoc />
     /// </summary>
-    /// <typeparam name="TEvent"></typeparam>
-    /// <typeparam name="TEventHandler"></typeparam>
-    /// <param name="handler"></param>
-    public void Unsubscribe<TEvent, TEventHandler>(TEventHandler handler)
-        where TEvent : IEvent
-        where TEventHandler : IEventHandler<TEvent>
-    {
-      if (handler == null) return;
-
-      Unsubscribe<TEvent, TEventHandler>(new[]
-      {
-                handler
-            });
-    }
+    /// <param name="handlers"></param>
+    public abstract void RegisterCatchAllHandler(params ICatchAllEventHandler[] handlers);
 
     /// <summary>
     ///     <inheritdoc />
     /// </summary>
     /// <param name="handlers"></param>
-    public abstract void RegisterCatchAllHandler(IEnumerable<ICatchAllEventHandler> handlers);
-
-    /// <summary>
-    ///     <inheritdoc />
-    /// </summary>
-    /// <param name="handler"></param>
-    public void RegisterCatchAllHandler(ICatchAllEventHandler handler)
-    {
-      if (handler == null) return;
-
-      RegisterCatchAllHandler(new[]
-      {
-                handler
-            });
-    }
-
-    /// <summary>
-    ///     <inheritdoc />
-    /// </summary>
-    /// <param name="handlers"></param>
-    public abstract void UnregisterCatchAllHandler(IEnumerable<ICatchAllEventHandler> handlers);
-
-    /// <summary>
-    ///     <inheritdoc />
-    /// </summary>
-    /// <param name="handler"></param>
-    public void UnregisterCatchAllHandler(ICatchAllEventHandler handler)
-    {
-      if (handler == null) return;
-
-      UnregisterCatchAllHandler(new[]
-      {
-                handler
-            });
-    }
+    public abstract void UnregisterCatchAllHandler(params ICatchAllEventHandler[] handlers);
 
     /// <summary>
     ///     Use this to release resources

--- a/libc.eventbus/System/IEventSink.cs
+++ b/libc.eventbus/System/IEventSink.cs
@@ -1,48 +1,24 @@
 ﻿using libc.eventbus.Types;
 using System;
-using System.Collections.Generic;
 
-namespace libc.eventbus.System
+namespace libc.eventbus.System;
+
+/// <summary>
+///     Implement to have a sink to allow other parts of application to subscribe to events
+/// </summary>
+public interface IEventSink : IDisposable
 {
-  /// <summary>
-  ///     Implement to have a sink to allow other parts of application to subscribe to events
-  /// </summary>
-  public interface IEventSink : IDisposable
-  {
     /// <summary>
     ///     Registers catch-all event handlers
     /// </summary>
     /// <param name="handlers"></param>
-    void RegisterCatchAllHandler(IEnumerable<ICatchAllEventHandler> handlers);
-
-    /// <summary>
-    ///     Registers a catch-all event handler
-    /// </summary>
-    /// <param name="handlers"></param>
-    void RegisterCatchAllHandler(ICatchAllEventHandler handler);
+    void RegisterCatchAllHandler(params ICatchAllEventHandler[] handlers);
 
     /// <summary>
     ///     Unregisters given catch-all event handlers
     /// </summary>
     /// <param name="handlers"></param>
-    void UnregisterCatchAllHandler(IEnumerable<ICatchAllEventHandler> handlers);
-
-    /// <summary>
-    ///     Unregisters given catch-all event handler
-    /// </summary>
-    /// <param name="handlers"></param>
-    void UnregisterCatchAllHandler(ICatchAllEventHandler handler);
-
-    /// <summary>
-    ///     Subscribe your handlers to an event.
-    ///     If a handler instance is equal to one defined before, this method SHOULD overwrite previous one
-    /// </summary>
-    /// <typeparam name="TEvent"></typeparam>
-    /// <typeparam name="TEventHandler"></typeparam>
-    /// <param name="handlers"></param>
-    void Subscribe<TEvent, TEventHandler>(IEnumerable<TEventHandler> handlers)
-        where TEvent : IEvent
-        where TEventHandler : IEventHandler<TEvent>;
+    void UnregisterCatchAllHandler(params ICatchAllEventHandler[] handlers);
 
     /// <summary>
     ///     Subscribe your handler to an event.
@@ -51,7 +27,7 @@ namespace libc.eventbus.System
     /// <typeparam name="TEvent"></typeparam>
     /// <typeparam name="TEventHandler"></typeparam>
     /// <param name="handler"></param>
-    void Subscribe<TEvent, TEventHandler>(TEventHandler handler)
+    void Subscribe<TEvent, TEventHandler>(params TEventHandler[] handlers)
         where TEvent : IEvent
         where TEventHandler : IEventHandler<TEvent>;
 
@@ -61,18 +37,7 @@ namespace libc.eventbus.System
     /// <typeparam name="TEvent"></typeparam>
     /// <typeparam name="TEventHandler"></typeparam>
     /// <param name="handlers"></param>
-    void Unsubscribe<TEvent, TEventHandler>(IEnumerable<TEventHandler> handlers)
+    void Unsubscribe<TEvent, TEventHandler>(params TEventHandler[] handlers)
         where TEvent : IEvent
         where TEventHandler : IEventHandler<TEvent>;
-
-    /// <summary>
-    ///     Unsubscribe your handler from an event
-    /// </summary>
-    /// <typeparam name="TEvent"></typeparam>
-    /// <typeparam name="TEventHandler"></typeparam>
-    /// <param name="handlers"></param>
-    void Unsubscribe<TEvent, TEventHandler>(TEventHandler handler)
-        where TEvent : IEvent
-        where TEventHandler : IEventHandler<TEvent>;
-  }
 }

--- a/libc.eventbus/libc.eventbus.csproj
+++ b/libc.eventbus/libc.eventbus.csproj
@@ -6,7 +6,7 @@
     <Authors>Saeed Farahi Mohassel</Authors>
     <Product>An in-memory event bus for services to communicate in-process</Product>
     <RepositoryUrl>https://github.com/saeidjoker/libc.eventbus</RepositoryUrl>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>

--- a/libc.eventbus/libc.eventbus.csproj
+++ b/libc.eventbus/libc.eventbus.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/saeidjoker/libc.eventbus</RepositoryUrl>
     <LangVersion>8.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
For having a clean parameter input and removing redundant methods with one input, I changed methods with having params type parameter.