### PR TITLE
Update target frameworks

### DIFF
--- a/libc.eventbus.tests/libc.eventbus.tests.csproj
+++ b/libc.eventbus.tests/libc.eventbus.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/libc.eventbus.tests/libc.eventbus.tests.csproj
+++ b/libc.eventbus.tests/libc.eventbus.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/libc.eventbus/libc.eventbus.csproj
+++ b/libc.eventbus/libc.eventbus.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>7.0.1</Version>
+    <Version>7.1.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Saeed Farahi Mohassel</Authors>
     <Product>An in-memory event bus for services to communicate in-process</Product>
     <RepositoryUrl>https://github.com/sfmohassel/libc.eventbus</RepositoryUrl>
     <LangVersion>8.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
With this commit the target frameworks are updated to include .NET Standard 2.0 (and through that all .NET Frameworks 4.6.2 and higher) and .NET 8 (the latest LTS).
.NET 7 support is removed as it is no longer supported. The test project target frameworks include .NET 4.6.2 to showcase compatibility with that version.

Fixes: #7 